### PR TITLE
Mark as abandoned, superseded by smartassert/dom-identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,6 @@
         "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6"
-    }
+    },
+    "abandoned": "/smartassert/dom-identifier"
 }


### PR DESCRIPTION
Fixes #47